### PR TITLE
fix(dataset):use tf compat for read_file

### DIFF
--- a/dataset.py
+++ b/dataset.py
@@ -21,7 +21,7 @@ class Dataset(object):
 
     def __getitem__(self, idx):
         if self.use_fast_loader:
-            hr = tf.read_file(self.image_files[idx])
+            hr = tf.compat.v1.read_file(self.image_files[idx])
             hr = tf.image.decode_jpeg(hr, channels=3)
             hr = pil_image.fromarray(hr.numpy())
         else:


### PR DESCRIPTION
Using `tf.read_file` on TF2.x would give an `AttributeError` stating that there is no such attribute.
This is because TF2 does not implement this attribute and if we are to use it properly in a TF2 application, we should use the `tf.compat.v1.read_file` instead.